### PR TITLE
feat(t2c): fixed single-agent session selection for Tier 2 demo (#19)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -656,7 +656,7 @@ of scope.
             *demo-session-id* nil guard returns 503; :mock-client fallback for
             offline tests; 2 new FiveAM specs (nil-session + with-session).
 
-- [ ] **T2.c** fixed single-agent session selection
+- [x] **T2.c** fixed single-agent session selection
       Implements: `scripts/boot-hub.lisp` (spawn one claude session via
                   deckpilot on boot, store id in `*demo-session-id*`),
                   `docs/tier-2/agent-choice.md`
@@ -665,6 +665,10 @@ of scope.
            `*demo-session-id*` resolvable from Lisp REPL; rationale for
            picking `claude -p` (vs gemini / codex) documented.
       Est: 1-2h · Agent hint: Main Claude
+      Done: 2026-04-21 — boot-hub.lisp --demo mode: start :8090 + spawn-demo-agent
+            via deckpilot launch sonnet; parse-demo-session-name pure fn in
+            cp-ui-bridge.lisp (exported); 3 FiveAM tests (simple/multiline/bad).
+            T1.c smoke (no-args) preserved intact.
 
 - [ ] **T2.d** end-to-end round-trip reflected in iframe
       Implements: manual test script `scripts/t2-e2e.lisp` (+ log)

--- a/docs/tier-2/agent-choice.md
+++ b/docs/tier-2/agent-choice.md
@@ -40,7 +40,23 @@ of relying on the CLI default.
 
 ## Wiring into `scripts/boot-hub.lisp`
 
-On startup, `scripts/boot-hub.lisp` asks deckpilot to spawn exactly one
-ghostty-win session whose child process is `claude --model sonnet`, then
-stores the returned session id in `*demo-session-id*` for
-`pipeline-cp:send-input` to target.
+Pass `--demo` to enter demo mode:
+
+```
+sbcl --script scripts/boot-hub.lisp --demo
+```
+
+On startup the script calls `spawn-demo-agent`, which runs:
+
+```
+deckpilot launch sonnet "hub ready, awaiting first input" --cwd <repo-root>
+```
+
+deckpilot expands `sonnet` to `claude --dangerously-skip-permissions --model sonnet`,
+creates a ghostty-win session, and returns the session name (e.g. `ghostty-12345`)
+on stdout.  `parse-demo-session-name` extracts the last non-empty line and sets
+`photo-ai-lisp:*demo-session-id*`, which `input-bridge-handler` (T2.b) targets
+for subsequent CP INPUT frames.
+
+Without `--demo` the script runs the T1.c smoke (connect → LIST → disconnect →
+exit 0), which CI depends on and must not be broken.

--- a/scripts/boot-hub.lisp
+++ b/scripts/boot-hub.lisp
@@ -1,8 +1,11 @@
 ;;;; scripts/boot-hub.lisp
 ;;;; T1.c — boot-hub smoke: connect, LIST, disconnect, exit 0.
+;;;; T2.c — boot-hub demo mode: start hub + spawn one sonnet session
+;;;;         via deckpilot, then loop forever.
 ;;;;
 ;;;; Usage:
-;;;;   sbcl --script scripts/boot-hub.lisp
+;;;;   sbcl --script scripts/boot-hub.lisp            ; T1.c smoke (CI)
+;;;;   sbcl --script scripts/boot-hub.lisp --demo     ; T2.c demo mode
 ;;;;
 ;;;; Exit 0 on success, 1 on any error.
 
@@ -32,32 +35,95 @@
         do (sleep interval)
         finally (return nil)))
 
-(handler-case
-    (progn
-      (format t "[BOOT] photo-ai-lisp hub smoke start~%")
-      (let* ((client (connect-cp :port 8080))
-             (driver (cp-client-driver client))
-             (ready (and driver (%wait-ws-open driver))))
-        ;; GCA-2: check actual WebSocket handshake, not just object creation.
-        (unless ready
-          (let ((state (and driver (wsd:ready-state driver))))
-            (format *error-output* "[BOOT] CONNECT: FAIL (ready-state=~A)~%" state)
-            (uiop:quit 1)))
-        (format t "[BOOT] connect ws://127.0.0.1:8080/ws -> OK~%")
+;;; ---- T2.c helpers ---------------------------------------------------------
 
-        ;; GCA-2: wrap blocking send-cp-command in a timeout to avoid hang.
-        (let ((resp (bt:with-timeout (5)
-                      (send-cp-command client (make-cp-list-tabs)))))
-          (unless (getf resp :ok)
-            (error "LIST returned non-ok: ~S" resp))
-          (format t "[BOOT] LIST ok=T session-count=~A~%"
-                  (length (getf resp :data))))
-        (ignore-errors (disconnect-cp client)))
-      (format t "[BOOT] ok~%")
-      (uiop:quit 0))
-  (bt:timeout ()
-    (format *error-output* "[BOOT] FATAL: send-cp-command timed out after 5 s~%")
-    (uiop:quit 1))
-  (error (c)
-    (format *error-output* "[BOOT] FATAL: ~A~%" c)
-    (uiop:quit 1)))
+(defun spawn-demo-agent (&key cwd)
+  "Launch one sonnet session via deckpilot and store the session id.
+
+   Runs: deckpilot launch sonnet \"hub ready, awaiting first input\" --cwd <cwd>
+   Captures stdout, extracts the session name via parse-demo-session-name,
+   and sets *demo-session-id*.  Calls uiop:quit 1 on failure."
+  (let* ((cwd-path (or cwd (namestring *repo-root*)))
+         (argv     (list "deckpilot" "launch" "sonnet"
+                         "hub ready, awaiting first input"
+                         "--cwd" cwd-path))
+         (output   (handler-case
+                       (uiop:run-program argv
+                                         :output :string
+                                         :error-output nil
+                                         :ignore-error-status t)
+                     (error (e)
+                       (format *error-output*
+                               "[DEMO] deckpilot exec error: ~A~%" e)
+                       (uiop:quit 1))))
+         (session  (parse-demo-session-name output)))
+    (unless session
+      (format *error-output*
+              "[DEMO] FATAL: could not parse session name from deckpilot output: ~S~%"
+              output)
+      (uiop:quit 1))
+    (setf *demo-session-id* session)
+    (format t "[DEMO] spawned ~A~%" session)))
+
+;;; ---- argument dispatch ----------------------------------------------------
+
+(defun demo-mode-p ()
+  "Return T when --demo is present in the POSIX argv."
+  (member "--demo" sb-ext:*posix-argv* :test #'string=))
+
+;;; ---- T1.c smoke (default, no args) ----------------------------------------
+
+(defun run-smoke ()
+  (handler-case
+      (progn
+        (format t "[BOOT] photo-ai-lisp hub smoke start~%")
+        (let* ((client (connect-cp :port 8080))
+               (driver (cp-client-driver client))
+               (ready (and driver (%wait-ws-open driver))))
+          ;; GCA-2: check actual WebSocket handshake, not just object creation.
+          (unless ready
+            (let ((state (and driver (wsd:ready-state driver))))
+              (format *error-output* "[BOOT] CONNECT: FAIL (ready-state=~A)~%" state)
+              (uiop:quit 1)))
+          (format t "[BOOT] connect ws://127.0.0.1:8080/ws -> OK~%")
+
+          ;; GCA-2: wrap blocking send-cp-command in a timeout to avoid hang.
+          (let ((resp (bt:with-timeout (5)
+                        (send-cp-command client (make-cp-list-tabs)))))
+            (unless (getf resp :ok)
+              (error "LIST returned non-ok: ~S" resp))
+            (format t "[BOOT] LIST ok=T session-count=~A~%"
+                    (length (getf resp :data))))
+          (ignore-errors (disconnect-cp client)))
+        (format t "[BOOT] ok~%")
+        (uiop:quit 0))
+    (bt:timeout ()
+      (format *error-output* "[BOOT] FATAL: send-cp-command timed out after 5 s~%")
+      (uiop:quit 1))
+    (error (c)
+      (format *error-output* "[BOOT] FATAL: ~A~%" c)
+      (uiop:quit 1))))
+
+;;; ---- T2.c demo mode (--demo flag) -----------------------------------------
+
+(defun run-demo ()
+  (handler-case
+      (progn
+        ;; photo-ai-lisp already loaded at top; re-quickload is a no-op but kept
+        ;; here as a guard in case demo is invoked standalone in future.
+        (ql:quickload :photo-ai-lisp :silent t)
+        (start :port 8090)
+        (format t "[HUB] started on :8090~%")
+        (spawn-demo-agent :cwd (namestring *repo-root*))
+        (format t "[DEMO] session=~A~%" *demo-session-id*)
+        ;; Keep image alive so REPL (e.g. swank/sly) can inspect the var.
+        (loop (sleep 60)))
+    (error (c)
+      (format *error-output* "[DEMO] FATAL: ~A~%" c)
+      (uiop:quit 1))))
+
+;;; ---- Entry point ----------------------------------------------------------
+
+(if (demo-mode-p)
+    (run-demo)
+    (run-smoke))

--- a/src/cp-ui-bridge.lisp
+++ b/src/cp-ui-bridge.lisp
@@ -42,3 +42,25 @@
         (format nil "{\"ok\":true,\"session\":\"~a\",\"bytes\":~d}"
                 (%json-escape *demo-session-id*)
                 n-bytes))))
+
+;;; T2.c — parse-demo-session-name
+;;; Pure function: given the stdout string from `deckpilot launch`, extract
+;;; the session name (last non-empty line).  Returns nil on bad input so
+;;; callers can decide how to fail rather than propagating an error.
+
+(defun parse-demo-session-name (s)
+  "Extract the session name from DECKPILOT LAUNCH stdout string S.
+
+   Strategy:
+     1. Split S on newlines.
+     2. Take the last non-empty (after trim) token.
+     3. If that token starts with \"ghostty-\" return it, else return NIL.
+   NIL is also returned for NIL input or blank strings."
+  (when (and s (plusp (length s)))
+    (let* ((lines  (uiop:split-string s :separator '(#\Newline #\Return)))
+           (trimmed (remove-if (lambda (l) (zerop (length (string-trim " " l)))) lines))
+           (last-line (and trimmed (string-trim " " (car (last trimmed))))))
+      (when (and last-line
+                 (> (length last-line) 8)
+                 (string= "ghostty-" (subseq last-line 0 8)))
+        last-line))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -66,4 +66,6 @@
            ;; issue #19 — T2.b: CP UI bridge
            #:*demo-session-id*
            #:*demo-cp-client*
-           #:input-bridge-handler))
+           #:input-bridge-handler
+           ;; issue #19 — T2.c: demo session spawn utility
+           #:parse-demo-session-name))

--- a/tests/cp-ui-bridge-tests.lisp
+++ b/tests/cp-ui-bridge-tests.lisp
@@ -35,3 +35,27 @@
               "body should echo the session id")
       (5am:is (search "bytes" body)
               "body should contain byte count field"))))
+
+;; ---- T2.c — parse-demo-session-name unit tests ----------------------------
+
+(5am:test boot-hub-parse-demo-session-simple
+  "Single line 'ghostty-12345\\n' -> 'ghostty-12345'."
+  (5am:is (equal "ghostty-12345"
+                 (photo-ai-lisp:parse-demo-session-name
+                  (format nil "ghostty-12345~%")))
+          "simple ghostty session name must be returned verbatim"))
+
+(5am:test boot-hub-parse-demo-session-multiline
+  "Noise lines before the session name: last non-empty line wins."
+  (5am:is (equal "ghostty-67890"
+                 (photo-ai-lisp:parse-demo-session-name
+                  (format nil "some noise~%ghostty-67890~%")))
+          "last non-empty line should be returned even when prefix noise is present"))
+
+(5am:test boot-hub-parse-demo-session-bad-input
+  "Empty string and non-ghostty- prefix → nil."
+  (5am:is (null (photo-ai-lisp:parse-demo-session-name ""))
+          "empty string must return nil")
+  (5am:is (null (photo-ai-lisp:parse-demo-session-name
+                 (format nil "notasession~%")))
+          "line not starting with ghostty- must return nil"))


### PR DESCRIPTION
## DoD (BACKLOG L664-666)

- [x] Boot script creates exactly one agent session on startup (`--demo` mode)
- [x] `*demo-session-id*` resolvable from Lisp REPL after `run-demo` completes
- [x] Rationale for picking `claude` (vs gemini / codex) documented in `docs/tier-2/agent-choice.md` (pre-existing, wiring section updated to match implementation)

## Changes

- `scripts/boot-hub.lisp`: `--demo` flag added; `run-smoke` (T1.c, no args) is preserved exactly — no regression risk for CI. `run-demo` starts hunchentoot on `:8090`, calls `spawn-demo-agent` (list-form `uiop:run-program`, no shell escaping), then loops forever so `*demo-session-id*` stays inspectable from REPL/swank.
- `src/cp-ui-bridge.lisp`: `parse-demo-session-name` pure fn — splits stdout on newlines, trims whitespace, returns last non-empty line iff it starts with `"ghostty-"`, else `nil`.
- `src/package.lisp`: `#:parse-demo-session-name` exported.
- `tests/cp-ui-bridge-tests.lisp`: 3 FiveAM pure-unit tests (`boot-hub-parse-demo-session-simple`, `-multiline`, `-bad-input`).
- `docs/tier-2/agent-choice.md`: Wiring section rewritten to match actual `deckpilot launch sonnet` contract.
- `BACKLOG.md`: T2.c ticked `[x]`.

## Remaining (not in this PR)

- T2.d — end-to-end round-trip reflected in iframe
- T2.g — demo evidence (PNG + log + README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)